### PR TITLE
fix: search bar now matches first characters (case-insensitive)

### DIFF
--- a/lib/features/auth/presentation/pages/homepage/homepage_desktop.dart
+++ b/lib/features/auth/presentation/pages/homepage/homepage_desktop.dart
@@ -86,8 +86,12 @@ class _HomepageDesktopState extends State<HomepageDesktop> {
                                 : notes
                                     .where(
                                       (note) =>
-                                          note.noteTitle.contains(searchText) ||
-                                          note.noteContent.contains(searchText),
+                                          note.noteTitle.toLowerCase().contains(
+                                            searchText,
+                                          ) ||
+                                          note.noteContent
+                                              .toLowerCase()
+                                              .contains(searchText),
                                     )
                                     .toList();
                         return NotesGridLayout(

--- a/lib/features/auth/presentation/pages/homepage/homepage_mobile.dart
+++ b/lib/features/auth/presentation/pages/homepage/homepage_mobile.dart
@@ -117,8 +117,12 @@ class _HomepageMobileState extends State<HomepageMobile> {
                               notes
                                   .where(
                                     (note) =>
-                                        note.noteTitle.contains(searchText) ||
-                                        note.noteContent.contains(searchText),
+                                        note.noteTitle.toLowerCase().contains(
+                                          searchText,
+                                        ) ||
+                                        note.noteContent.toLowerCase().contains(
+                                          searchText,
+                                        ),
                                   )
                                   .toList();
 
@@ -155,7 +159,7 @@ class _HomepageMobileState extends State<HomepageMobile> {
           onPageSelected: (NotePageType page) {
             setState(() {
               selectedPageType = page;
-             // print(selectedPageType);
+              // print(selectedPageType);
               context.read<NotesBloc>().add(
                 NotePageOptionPressedEvent(selectedNotePage: selectedPageType),
               );


### PR DESCRIPTION
### Problem
Search bar did not match note titles starting with capital letters (e.g., "Hello" not found when typing "h").

### Fix
Added `.toLowerCase()` to `note.noteTitle` and `note.noteContent` to make `.contains()` case-insensitive on desktop, tablet and mobile views.

Closes #1